### PR TITLE
[ai-sre] add ledger-reconciliation-agent interview exercise

### DIFF
--- a/ai/ledger-reconciliation-agent/.gitignore
+++ b/ai/ledger-reconciliation-agent/.gitignore
@@ -1,0 +1,5 @@
+package-lock.json
+node_modules/
+*~
+.*~
+dist/

--- a/ai/ledger-reconciliation-agent/README.md
+++ b/ai/ledger-reconciliation-agent/README.md
@@ -1,0 +1,74 @@
+# Ledger Reconciliation Agent
+
+This is a live-coding exercise for AI Platform Engineer candidates.
+
+The candidate may use any process of their choosing: any language, any agent, any LLM -- or none at all if you prefer. TypeScript is a sensible default. Bring your own Claude / Cursor / etc., or we can provision a Gemini API key at the start of the session.
+
+## The task
+
+You are a Platform Engineer who accelerates other team's AI implementations. The Operations team reconciles our internal ledger against the card processor's settlement file every morning. The two systems were built by different vendors at different times and they reflect activity at different granularity — the processor's file shows one entry per settlement (an omnibus aggregate), our internal ledger shows one entry per member's virtual account. IDs do not survive the boundary, the internal ledger is exported by hand from a spreadsheet that an analyst maintains, and we are not always sure what to do with bursts of identical-amount transactions on the same day. Ops is currently doing this reconciliation by eye in Excel and they are tired.
+
+**Your job is to build an agent loop that reconciles the two ledgers and produces (a) a list of committed matches and (b) a list of entries that cannot be matched, with a reason.**
+
+The processor's settlements live in [`processor_ledger.json`](./processor_ledger.json). The internal ledger lives in [`internal_ledger.csv`](./internal_ledger.csv). The panel's expected match set lives in [`expected_matches.json`](./expected_matches.json) — you may use it to self-test, and we will grade against it.
+
+Think out loud. There is no "finished" state we are looking for — we want to see how you reason about the agent loop, the tool surface, search, confidence, and termination. Treat the panel as your team; ask us anything.
+
+## The data
+
+- [`processor_ledger.json`](./processor_ledger.json): 8 omnibus-level settlements emitted by the card processor. Clean, machine-generated. Amounts in integer cents.
+- [`internal_ledger.csv`](./internal_ledger.csv): 11 per-virtual-account entries from our internal ledger. Hand-typed-feeling. Amounts in dollar-decimal (parse to cents on load).
+- [`expected_matches.json`](./expected_matches.json): the ground-truth match set with category labels (`1:1`, `M:N aggregation`, `burst`, `unmatched`, `1:1 with date variance`).
+
+The two ledgers cover the same business activity over five days (2026-04-15 to 2026-04-19) but represent it at different granularity. Some processor entries correspond to a single internal entry; some correspond to many internal entries that sum to the processor's amount; some have no internal counterpart at all.
+
+## The tools
+
+Three async functions are exported from [`src/index.ts`](./src/index.ts) and ready to be wired up as tools the model can call:
+
+- `list_unmatched(side, date_range?)` — returns the still-unmatched entries on the given side (`"processor"` or `"internal"`), optionally filtered by date range.
+- `find_groups_summing_to(side, target_cents, tolerance_cents, max_group_size, date_range?)` — searches the unmatched entries on `side` for groupings of 1..`max_group_size` entries whose amounts sum to `target_cents` ± `tolerance_cents`. Returns up to 20 candidate groupings; if the search would return more, it returns the first 20 and indicates truncation. Use this when you have a target amount and you want plausible groups on the other side.
+- `commit_match(processor_ids, internal_ids, reason)` — atomically validates the proposed match (all ids must currently be unmatched; sums on each side must be equal within tolerance) and records it. Returns `{ ok: true }` on success or `{ ok: false, error: "..." }` on failure. Idempotent: re-committing the same match is an error, not a silent success.
+
+You decide how to declare these tools to the model, how to parse the model's tool calls, how to dispatch them, and how to feed the results back into the conversation. State (which entries are matched) lives in-process and resets when the process restarts.
+
+## The output
+
+Your agent's final terminal output should be two lists:
+
+1. **Committed matches.** Either obtained by calling `list_unmatched` after the loop terminates and reporting the diff, or accumulated as the agent commits.
+2. **Flagged unmatchable entries.** Entries the agent has decided cannot be confidently matched, with a reason.
+
+Format is up to you — JSON is sensible. Tell us why you chose what you chose.
+
+## Guidelines
+
+- Use any language, runtime, and LLM you are comfortable with.
+- You may modify, extend, or replace the dataset, the ledgers, or the tool surface.
+- You may decide to skip the LLM entirely on certain entries (e.g., obvious 1:1 by amount + date + narrative). Tell us why and where you draw the line.
+- Treat the panel as your team. Ask clarifying questions, push back, request things.
+
+## Setup
+
+If you brought your own tooling (Claude Code, Cursor, a local repo, etc.), use it. Otherwise tell us and we will provision an API token and a scratch environment.
+
+A minimal TypeScript scaffold is provided in [`src/index.ts`](./src/index.ts) — `getClient`, `callModel`, `loadPrompt`, the three tool implementations, and CSV/JSON load helpers. It expects `GEMINI_API_KEY` in the environment and will throw if it is missing. Use it, ignore it, rewrite it, or work in another language entirely.
+
+```
+npm install
+export GEMINI_API_KEY=...
+```
+
+### Possible run commands
+
+Using `tsx`:
+
+```
+GEMINI_API_KEY=... npx tsx src/index.ts
+```
+
+Using `tsc`:
+
+```
+npx tsc && GEMINI_API_KEY=... node dist/index.js
+```

--- a/ai/ledger-reconciliation-agent/expected_matches.json
+++ b/ai/ledger-reconciliation-agent/expected_matches.json
@@ -1,0 +1,18 @@
+[
+  {"processor_ids": ["S001"], "internal_ids": ["L01"], "category": "1:1"},
+  {"processor_ids": ["S002"], "internal_ids": ["L02", "L03", "L04", "L05"], "category": "M:N aggregation"},
+  {"processor_ids": ["S003"], "internal_ids": ["L06", "L07"], "category": "M:N aggregation"},
+  {
+    "processor_ids": ["S004", "S005", "S006"],
+    "internal_ids": ["L08", "L09", "L10"],
+    "category": "burst",
+    "note": "Any 1:1 permutation of these three pairs is also acceptable; commit as three matches or one many-to-many."
+  },
+  {"processor_ids": ["S007"], "internal_ids": [], "category": "unmatched", "reason": "No internal counterpart on or near 2026-04-18 with amount 34000"},
+  {
+    "processor_ids": ["S008"],
+    "internal_ids": ["L11"],
+    "category": "1:1 with date variance",
+    "note": "Internal posted_date is 2026-04-18, settlement is 2026-04-19. Acceptable to commit with note, or flag for human review."
+  }
+]

--- a/ai/ledger-reconciliation-agent/internal_ledger.csv
+++ b/ai/ledger-reconciliation-agent/internal_ledger.csv
@@ -1,0 +1,12 @@
+id,posted_date,member_id,amount,type,note
+L01,2026-04-15,M-1001,125.00,card_purchase,CVS Pharmacy #4421
+L02,2026-04-15,M-1002,150.00,payroll,Employer ACH
+L03,2026-04-15,M-1003,250.00,payroll,Employer ACH
+L04,2026-04-15,M-1004,200.00,payroll,Employer ACH
+L05,2026-04-15,M-1005,290.00,payroll,Employer ACH
+L06,2026-04-16,M-1001,250.00,card_purchase,WALGREENS #4321
+L07,2026-04-16,M-1006,200.00,card_purchase,Walgreens
+L08,2026-04-17,M-1001,75.00,card_purchase,Amazon
+L09,2026-04-17,M-1007,75.00,card_purchase,Amazon
+L10,2026-04-17,M-1008,75.00,card_purchase,Amazon
+L11,2026-04-18,M-1009,60.00,card_purchase,Target

--- a/ai/ledger-reconciliation-agent/package.json
+++ b/ai/ledger-reconciliation-agent/package.json
@@ -1,0 +1,9 @@
+{
+  "dependencies": {
+    "@google/genai": "1.50.1"
+  },
+  "devDependencies": {
+    "@types/node": "22.19.17",
+    "typescript": "5.9.3"
+  }
+}

--- a/ai/ledger-reconciliation-agent/processor_ledger.json
+++ b/ai/ledger-reconciliation-agent/processor_ledger.json
@@ -1,0 +1,10 @@
+[
+  {"id": "S001", "date": "2026-04-15", "amount_cents": 12500, "type": "card_settlement", "merchant": "CVS"},
+  {"id": "S002", "date": "2026-04-15", "amount_cents": 89000, "type": "ach_credit", "narrative": "Employer payroll batch"},
+  {"id": "S003", "date": "2026-04-16", "amount_cents": 45000, "type": "card_settlement", "merchant": "Walgreens"},
+  {"id": "S004", "date": "2026-04-17", "amount_cents": 7500, "type": "card_settlement", "merchant": "AMAZON"},
+  {"id": "S005", "date": "2026-04-17", "amount_cents": 7500, "type": "card_settlement", "merchant": "AMAZON"},
+  {"id": "S006", "date": "2026-04-17", "amount_cents": 7500, "type": "card_settlement", "merchant": "AMAZON"},
+  {"id": "S007", "date": "2026-04-18", "amount_cents": 34000, "type": "internal_transfer", "narrative": "Quarterly fee allocation"},
+  {"id": "S008", "date": "2026-04-19", "amount_cents": 6000, "type": "card_settlement", "merchant": "Target"}
+]

--- a/ai/ledger-reconciliation-agent/src/index.ts
+++ b/ai/ledger-reconciliation-agent/src/index.ts
@@ -1,0 +1,153 @@
+import { GoogleGenAI } from "@google/genai";
+import { readFileSync } from "node:fs";
+
+export function getClient(): GoogleGenAI {
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!apiKey) {
+    throw new Error("GEMINI_API_KEY is not set");
+  }
+  return new GoogleGenAI({ apiKey });
+}
+
+export async function callModel(
+  prompt: string,
+  model: string = "gemini-2.5-flash-lite"
+): Promise<string> {
+  const response = await getClient().models.generateContent({
+    model,
+    contents: prompt,
+  });
+  return response.text ?? "";
+}
+
+export function loadPrompt(
+  path: string,
+  vars: Record<string, string> = {}
+): string {
+  return Object.entries(vars).reduce(
+    (template, [key, value]) => template.split(`{${key}}`).join(value),
+    readFileSync(path, "utf8")
+  );
+}
+
+type Side = "processor" | "internal";
+
+type Entry = {
+  id: string;
+  date: string;
+  amount_cents: number;
+  side: Side;
+  raw: Record<string, unknown>;
+};
+
+const PROCESSOR: Entry[] = JSON.parse(
+  readFileSync("./processor_ledger.json", "utf8")
+).map((row: Record<string, unknown>) => ({
+  id: row.id as string,
+  date: row.date as string,
+  amount_cents: row.amount_cents as number,
+  side: "processor",
+  raw: row,
+}));
+
+const INTERNAL: Entry[] = readFileSync("./internal_ledger.csv", "utf8")
+  .trim()
+  .split("\n")
+  .slice(1)
+  .map((line) => {
+    const [id, posted_date, member_id, amount, type, note] = line.split(",");
+    return {
+      id,
+      date: posted_date,
+      amount_cents: Math.round(parseFloat(amount) * 100),
+      side: "internal" as Side,
+      raw: { id, posted_date, member_id, amount, type, note },
+    };
+  });
+
+const MATCHED = new Set<string>();
+
+function inDateRange(entry: Entry, range?: { from: string; to: string }): boolean {
+  if (!range) return true;
+  return entry.date >= range.from && entry.date <= range.to;
+}
+
+export async function list_unmatched(
+  side: Side,
+  date_range?: { from: string; to: string }
+): Promise<Entry[]> {
+  const source = side === "processor" ? PROCESSOR : INTERNAL;
+  return source.filter((e) => !MATCHED.has(e.id) && inDateRange(e, date_range));
+}
+
+export async function find_groups_summing_to(
+  side: Side,
+  target_cents: number,
+  tolerance_cents: number,
+  max_group_size: number,
+  date_range?: { from: string; to: string }
+): Promise<{ group_ids: string[]; sum_cents: number; truncated: boolean }[]> {
+  const pool = (await list_unmatched(side, date_range));
+  const results: { group_ids: string[]; sum_cents: number; truncated: boolean }[] = [];
+  const cap = 20;
+
+  function search(start: number, picked: Entry[], sum: number) {
+    if (results.length >= cap) return;
+    if (picked.length > 0 && Math.abs(sum - target_cents) <= tolerance_cents) {
+      results.push({ group_ids: picked.map((p) => p.id), sum_cents: sum, truncated: false });
+    }
+    if (picked.length >= max_group_size) return;
+    for (let i = start; i < pool.length; i++) {
+      search(i + 1, [...picked, pool[i]], sum + pool[i].amount_cents);
+      if (results.length >= cap) return;
+    }
+  }
+  search(0, [], 0);
+
+  const truncated = results.length >= cap;
+  return results.map((r) => ({ ...r, truncated }));
+}
+
+export async function commit_match(
+  processor_ids: string[],
+  internal_ids: string[],
+  reason: string
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  if (processor_ids.length === 0 && internal_ids.length === 0) {
+    return { ok: false, error: "Both sides empty" };
+  }
+  for (const id of [...processor_ids, ...internal_ids]) {
+    if (MATCHED.has(id)) {
+      return { ok: false, error: `Already matched: ${id}` };
+    }
+  }
+  const sumA = processor_ids.reduce(
+    (s, id) => s + (PROCESSOR.find((e) => e.id === id)?.amount_cents ?? NaN),
+    0
+  );
+  const sumB = internal_ids.reduce(
+    (s, id) => s + (INTERNAL.find((e) => e.id === id)?.amount_cents ?? NaN),
+    0
+  );
+  if (Number.isNaN(sumA) || Number.isNaN(sumB)) {
+    return { ok: false, error: "Unknown id" };
+  }
+  if (Math.abs(sumA - sumB) > 100) {
+    return { ok: false, error: `Sum mismatch: processor=${sumA} internal=${sumB}` };
+  }
+  for (const id of [...processor_ids, ...internal_ids]) MATCHED.add(id);
+  void reason;
+  return { ok: true };
+}
+
+// Example usage
+if (require.main === module) {
+  (async () => {
+    const settlements = await list_unmatched("processor");
+    console.log(`Loaded ${settlements.length} unmatched processor entries.`);
+    const reply = await callModel(
+      `Summarize this ledger entry in one short sentence: ${JSON.stringify(settlements[0].raw)}`
+    );
+    console.log(reply);
+  })();
+}

--- a/ai/ledger-reconciliation-agent/tsconfig.json
+++ b/ai/ledger-reconciliation-agent/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["es2020"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es2020"
+  },
+  "exclude": ["node_modules"],
+  "include": ["./src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Adds a new live-coding interview exercise for AI Platform Engineer candidates at `ai/ledger-reconciliation-agent/`. The candidate is asked to build an agent loop that reconciles a card-processor settlement file against an internal per-virtual-account ledger and reports committed matches plus flagged unmatchable entries.

The exercise ships with:

- `processor_ledger.json` — 8 omnibus-level settlements
- `internal_ledger.csv` — 11 per-account entries
- `expected_matches.json` — reference match set
- `src/index.ts` — minimal TypeScript scaffold (`getClient`, `callModel`, `loadPrompt`) plus three pre-implemented tools (`list_unmatched`, `find_groups_summing_to`, `commit_match`) on top of `@google/genai`